### PR TITLE
fix: deprecated scrollbar_thumb property (#1)

### DIFF
--- a/themes/one-dark-pro-monokai-darker.json
+++ b/themes/one-dark-pro-monokai-darker.json
@@ -47,7 +47,7 @@
         "panel.background": "#181a1f",
         "panel.focused_border": null,
         "pane.focused_border": null,
-        "scrollbar_thumb.background": "#4e566680",
+        "scrollbar.thumb.background": "#4e566680",
         "scrollbar.thumb.hover_background": "#5a637580",
         "scrollbar.thumb.border": "#4e566680",
         "scrollbar.track.background": "#121212",


### PR DESCRIPTION
I'm not manually tested it but I hope it doesn't cause any `theme not found` warnings right now.
Fix: #1